### PR TITLE
Rebuild 0.5.3 everywhere

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,6 @@ build:
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319
 
 build:
-  number: 2
-  skip: true  # [py2k]
+  number: 3
+  skip: True  # [py2k]
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 3
-  noarch: python
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 3
   skip: True  # [py2k]
+  noarch: python
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ about:
   license_file: LICENSE
   summary: Python logging made (stupidly) simple
   dev_url: https://github.com/Delgan/loguru
+  doc_url: https://loguru.readthedocs.io/en/0.5.3/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 3
-  skip: True  # [py2k]
   noarch: python
   script: '{{ PYTHON }} -m pip install . -vv '
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
   run:
     - python >=3.5
     - colorama >=0.3.4        # [win]
@@ -27,6 +28,8 @@ requirements:
 test:
   imports:
     - loguru
+  commands:
+    - pip check
 
 about:
   home: https://github.com/Delgan/loguru

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - aiocontextvars          # [py36]
 
 test:
+  requires:
+    - pip
   imports:
     - loguru
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - python
   run:
-    - python
+    - python >=3.5
     - colorama >=0.3.4        # [win]
     - win32_setctime >=1.0.0  # [win]
     - aiocontextvars          # [py36]


### PR DESCRIPTION
This package was integrated for linux-64 and osx-arm64 and specific versions of Python only (see below).

```
--------------------------------------------------------------------
# noarch
--------------------------------------------------------------------
->Package "loguru" not found!

--------------------------------------------------------------------
# linux-64
--------------------------------------------------------------------
* loguru                         0.5.3 py310h06a4308_2  pkgs/main

--------------------------------------------------------------------
# linux-ppc64le
--------------------------------------------------------------------
->Package "loguru" not found!

--------------------------------------------------------------------
# linux-aarch64
--------------------------------------------------------------------
->Package "loguru" not found!

--------------------------------------------------------------------
# linux-s390x
--------------------------------------------------------------------
->Package "loguru" not found!

--------------------------------------------------------------------
# osx-64
--------------------------------------------------------------------
->Package "loguru" not found!

--------------------------------------------------------------------
# osx-arm64
--------------------------------------------------------------------
* loguru                         0.5.3  py38hca03da5_2  pkgs/main
* loguru                         0.5.3  py39hca03da5_2  pkgs/main

--------------------------------------------------------------------
# win-32
--------------------------------------------------------------------
->Package "loguru" not found!

--------------------------------------------------------------------
# win-64
--------------------------------------------------------------------
->Package "loguru" not found!
```