### PR TITLE
bumped build to trigger py310 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,17 @@ source:
 
 build:
   number: 4
-  script: '{{ PYTHON }} -m pip install . -vv '
+  script: {{ PYTHON }} -m pip install --no-deps . -vv
+  skip: True  # [py<35]
 
 requirements:
   host:
     - pip
     - python
     - setuptools
+    - wheel
   run:
-    - python >=3.5
+    - python
     - colorama >=0.3.4        # [win]
     - win32_setctime >=1.0.0  # [win]
     - aiocontextvars          # [py36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,13 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Python logging made (stupidly) simple
+  description: |
+    This library is intended to make Python logging less painful by adding
+    a bunch of useful functionalities that solve caveats of the standard loggers.
+    Using logs in your application should be an automatism, Loguru tries to
+    make it both pleasant and powerful.
   dev_url: https://github.com/Delgan/loguru
-  doc_url: https://loguru.readthedocs.io/en/0.5.3/
+  doc_url: https://loguru.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319
 
 build:
-  number: 3
+  number: 4
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:


### PR DESCRIPTION
### Overview
`loguru` is a dependency for `vtk` which is a dependency for `mayavi` (see Jira)

Jira: https://anaconda.atlassian.net/browse/PKG-1086
Upstream: https://github.com/Delgan/loguru

**Changes:**
- Bumped build from 3 to 4 to trigger build for py310
- Added a description
- Updated doc url
- added --no-deps for `pip install`
- removed single quotes from script
- added `skip: True  # [py<35]`
- added `wheel` to host
- removed python pinning

**_Please note:_**
The upstream suggests building for py>=35 [here](https://github.com/Delgan/loguru/blob/f31e97142adc1156693a26ecaf47208d3765a6e3/setup.py#L72), and we have `- aiocontextvars          # [py36]` in the run section, so I want to keep it to prevent inconsistency throughout the recipe. Please let me know your thoughts. Thanks!